### PR TITLE
Change sharecode format to be platform-independent

### DIFF
--- a/src/randomizer.lua
+++ b/src/randomizer.lua
@@ -399,7 +399,7 @@ function C:_updateSharecode(seed)
     seed = seed .. (" "):rep(20-#seed)
   end
 
-  local packed = love.data.pack("data", "sBB", seed, settings, seq)
+  local packed = love.data.pack("data", "<s1BB", seed, settings, seq)
   self.sharecode = love.data.encode("string", "base64", packed)
 
   logNotice(("Sharecode: %s"):format(self.sharecode))

--- a/src/ui/draw.lua
+++ b/src/ui/draw.lua
@@ -269,7 +269,7 @@ end)
 settings.importshare:onPress(function()
   local success, seed, sharesettings, seq = pcall(function()
     local packed = love.data.decode("data", "base64", settings.sharecode.value)
-    local seed, settings, seq = love.data.unpack("sBB", packed)
+    local seed, settings, seq = love.data.unpack("<s1BB", packed)
     assert(#seed == 20)
     return seed, settings, seq
   end)


### PR DESCRIPTION
When Lua packs a string using the `"s"` option, it prefixes the string by its length, which is coded as an integer of type `size_t` (using the native endian). In 32-bit LÖVE, `size_t` is a 4-byte integer, whereas in 64-bit LÖVE, `size_t` is 8 bytes. This explains the incompatibility of sharecodes between 32-bit and 64-bit LÖVE.

To guarantee platform independence, I've 1) explicitly specified an endianness (little) with the `"<"` option, and 2) specified the size of the string. Additionally, I propose the following change: Since the randomizer enforces that the seed will be no more than 20 characters long, that means only 1 byte is needed to represent its length. Hence we can make the format string `"<s1BB"`. (Of course, changing the string length to 1 byte already makes endianness not matter, but specifying it anyways doesn't hurt.)

This also has the effect of removing all of the "A"s from the beginning of every sharecode, which shortens them a bit and also looks nicer, in my opinion. :)

Example sharecodes (using the same seed/settings):
32-bit LÖVE (current master): `FAAAAGR1bmNhdGhhbiBpcyBjb29sIDoplz0=`
64-bit LÖVE (current master): `FAAAAAAAAABkdW5jYXRoYW4gaXMgY29vbCA6KZc9`
With the proposed change: `FGR1bmNhdGhhbiBpcyBjb29sIDoplz0=`